### PR TITLE
Added sentence command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "onCommand:string-manipulation.reverse",
     "onCommand:string-manipulation.swapCase",
     "onCommand:string-manipulation.decapitalize",
-    "onCommand:string-manipulation.capitalize"
+    "onCommand:string-manipulation.capitalize",
+    "onCommand:string-manipulation.sentence"
   ],
   "contributes": {
     "commands": [
@@ -107,7 +108,12 @@
         "title": "Capitalize",
         "category": "String Manipulation",
         "command": "string-manipulation.capitalize"
-      }
+      },
+      {
+        "title": "Sentence",
+        "category": "String Manipulation",
+        "command": "string-manipulation.sentence"
+      },
     ]
   },
   "scripts": {


### PR DESCRIPTION
See Issue #16, quote below

"The [sentence] command does not appear in the `package.json`. I'm assuming that is why I cannot find the command. I think I have fixed the issue in a file change proposal that I will submit shortly. Let me know if what I proposed will not help at all."