### PR TITLE
Add multiselect support for sequence command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -5,12 +5,11 @@ const chicagoStyleTitleCase = require("chicago-capitalize");
 const slugify = require("@sindresorhus/slugify");
 const defaultFunction = (commandName, option) => (str) =>
   _string[commandName](str, option);
-const sequence = (str) => {
-  let initial;
+const sequence = (str, multiselectData = {}) => {
   return str.replace(/-?\d+/g, (n) => {
-    const isFirst = typeof initial !== "number";
-    initial = isFirst ? Number(n) : initial + 1;
-    return initial;
+    const isFirst = typeof multiselectData.offset !== "number";
+    multiselectData.offset = isFirst ? Number(n) : multiselectData.offset + 1;
+    return multiselectData.offset;
   });
 };
 const increment = (str) => str.replace(/-?\d+/g, (n) => Number(n) + 1);
@@ -75,6 +74,7 @@ const stringFunction = async (commandName, context) => {
   const selectionMap = {};
   if (!editor) return;
 
+  let multiselectData = {};
   editor.selections.forEach(async (selection, index) => {
     const text = editor.document.getText(selection);
     const textParts = text.split("\n");
@@ -87,7 +87,7 @@ const stringFunction = async (commandName, context) => {
         .reduce((prev, curr) => prev.push(stringFunc(curr)) && prev, [])
         .join("\n");
     } else if (numberFunctionNames.includes(commandName)) {
-      replaced = commandNameFunctionMap[commandName](text);
+      replaced = commandNameFunctionMap[commandName](text, multiselectData);
     } else {
       stringFunc = commandNameFunctionMap[commandName];
       replaced = textParts

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -95,17 +95,24 @@ suite("Extension Test Suite", () => {
       "a14 b15 c16\n17d 18e 19f 20x y21 22z23",
     ],
     ["sequence", "-3 4 5 6 7", "-3 -2 -1 0 1"],
+    [
+      "sequence",
+      "1 2 3 7 8 9",
+      "4 5 6 7 8 9",
+      { multiselectData: { offset: 3 } },
+    ],
     ["utf8ToChar", "\\u0061\\u0062\\u0063\\u4e2d\\u6587\\ud83d\\udc96", "abc中文💖"],
     ["charToUtf8", "abc中文💖", "\\u0061\\u0062\\u0063\\u4e2d\\u6587\\ud83d\\udc96"],
   ];
   suite("commandNameFunctionMap outputs correctly for all methods", () => {
     tests.forEach(
-      ([funcName, originalString, expectedString, { functionArg } = {}]) => {
-        test(`${funcName} returns ${expectedString} when called with ${originalString}`, () => {
+      ([funcName, originalString, expectedString, { multiselectData, functionArg } = {}]) => {
+        const arguments = `${originalString}${multiselectData ? `, ${JSON.stringify(multiselectData)}` : ''}`;
+        test(`${funcName} returns ${expectedString} when called with ${arguments}`, () => {
           const func = functionArg
             ? myExtension.commandNameFunctionMap[funcName](functionArg)
             : myExtension.commandNameFunctionMap[funcName];
-          assert.equal(func(originalString), expectedString);
+          assert.equal(func(originalString, multiselectData), expectedString);
         });
       }
     );


### PR DESCRIPTION
First off, thanks for making this extension. It's super helpful.

This change improves the multiselect support for the sequence command by making it more consistent with [IntelliJ's String Manipulation plugin](https://plugins.jetbrains.com/plugin/2162-string-manipulation). I see the issue was already reported in #47.

This change adds a new `multiselectData` object that is passed to all number functions (although only `sequence` uses it currently) to allow data to be stored between calls. In this case, `sequence` uses it to keep track of the current number (offset) across selections. This allows the user to create a sequence of numbers in a column without affecting other numbers on each row. For example:

![image](https://github.com/user-attachments/assets/e5922290-3243-4adb-80b3-3de8e29f71db)

Becomes...

![image](https://github.com/user-attachments/assets/ac8d890e-3aad-4bf8-813b-0fedb52021bd)

Let me know if you have any questions or feedback, thanks.
